### PR TITLE
Use useWriteCache parameter when opening stream decks through a StreamDeckDeviceReference

### DIFF
--- a/src/StreamDeckSharp/StreamDeckDeviceReference.cs
+++ b/src/StreamDeckSharp/StreamDeckDeviceReference.cs
@@ -38,7 +38,7 @@ namespace StreamDeckSharp
         /// <inheritdoc/>
         public IMacroBoard Open(bool useWriteCache)
         {
-            return StreamDeck.OpenDevice(DevicePath);
+            return StreamDeck.OpenDevice(DevicePath, useWriteCache);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
The boolean parameter `useWriteCache` was ignored in the Open function on the StreamDeckDeviceReference. I don't know if this is intentional or not, but I ran into a use case where I didn't want to use the CachedHidClient. This change allows you to open the Stream Deck as a BasicHidClient.